### PR TITLE
Add twicpics as image cdn

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://netlify-cdp-loader.netlify.app https://cloud.umami.is; connect-src 'self' https://*.algolia.net https://*.algolianet.com https://api-gateway.umami.dev; img-src 'self' data: https://upload.wikimedia.org https://*.cloudimg.io https://tile.openstreetmap.org; child-src 'self' https://*.netlify.com;
+  Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://netlify-cdp-loader.netlify.app https://cloud.umami.is; connect-src 'self' https://*.algolia.net https://*.algolianet.com https://api-gateway.umami.dev; img-src 'self' data: https://upload.wikimedia.org https://*.cloudimg.io https://*.twic.pics https://tile.openstreetmap.org; child-src 'self' https://*.netlify.com;
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
 /static/*.css

--- a/src/helpers/image.js
+++ b/src/helpers/image.js
@@ -25,7 +25,7 @@ export const generateUrlWithPadding = (sourceUrl, width, height) => {
     url = url.replace('https://upload.wikimedia.org/wikipedia/', '')
 
     if (width || height) {
-      url = `${url}?w=${width || height}&h=${height || width}&func=fit`
+      url = `${url}?${cdnParams(cdnUrl, width, height)}`
     }
   }
 
@@ -50,4 +50,14 @@ export const generateUrl = (sourceUrl, large = false) => {
   }
 
   return url
+}
+
+const cdnParams = (cdnUrl, width, height) => {
+  if (cdnUrl.includes('cloudimg.io')) {
+    return `w=${width || height}&h=${height || width}&func=fit`
+  }
+
+  if (cdnUrl.includes('twic.pics')) {
+    return `inside=${width || height}x${height || width}`
+  }
 }

--- a/src/helpers/image.js
+++ b/src/helpers/image.js
@@ -58,6 +58,6 @@ const cdnParams = (cdnUrl, width, height) => {
   }
 
   if (cdnUrl.includes('twic.pics')) {
-    return `inside=${width || height}x${height || width}`
+    return `twic=v1/inside=${width || height}x${height || width}(10p)`
   }
 }


### PR DESCRIPTION
Add possibility to choose twicpics as image CDN
I did that because, Cloudimage is ending free tier